### PR TITLE
add new Map methods introduced in OCaml 4.07

### DIFF
--- a/ptmap.ml
+++ b/ptmap.ml
@@ -354,3 +354,25 @@ let update x f m =
   match f (find_opt x m) with
   | None -> remove x m
   | Some z -> add x z m
+
+let to_seq m =
+  let rec prepend_seq m s = match m with
+    | Empty -> s
+    | Leaf (k, v) -> fun () -> Seq.Cons((k,v), s)
+    | Branch (_, _, l, r) -> prepend_seq l (prepend_seq r s)
+  in
+  prepend_seq m Seq.empty
+
+let to_seq_from k m =
+  let rec prepend_seq m s = match m with
+    | Empty -> s
+    | Leaf (key, v) -> if key >= k then fun () -> Seq.Cons((key,v), s) else s
+    | Branch (_, _, l, r) -> prepend_seq l (prepend_seq r s)
+  in
+  prepend_seq m Seq.empty
+
+let add_seq s m =
+  Seq.fold_left (fun m (k, v) -> add k v m) m s
+
+let of_seq s =
+  Seq.fold_left (fun m (k, v) -> add k v m) empty s

--- a/test.ml
+++ b/test.ml
@@ -62,6 +62,33 @@ let test_update_update =
   | Some false -> assert true
   | _ -> assert true
 
+let test_to_seq =
+  let o = [3; 1; 2; 4; 6; 5] in
+  let l = List.of_seq (Ptmap.to_seq (list_to_map o)) in
+  assert (List.length l = List.length o);
+  assert (List.for_all (fun (k,v) -> List.exists (fun ok -> ok = k) o) l)
+
+let test_to_seq_from =
+  let o = [3; 1; 2; 4; 6; 5] in
+  let r = [3; 4; 5; 6] in
+  let l = List.of_seq (Ptmap.to_seq_from 3 (list_to_map o)) in
+  assert (List.length l = List.length r);
+  assert (List.for_all (fun (k,v) -> List.exists (fun ok -> ok = k) r) l)
+
+let test_of_seq =
+  let o = [3; 1; 2; 4; 6; 5] in
+  let m = Ptmap.of_seq (List.to_seq (List.map (fun v -> (v, true)) o)) in
+  assert (Ptmap.cardinal m = List.length o);
+  assert (Ptmap.for_all (fun k v -> List.exists (fun ok -> ok = k) o) m)
+
+let test_add_seq =
+  let o = [3; 1; 6; 5] in
+  let a = [2; 4] in
+  let r = [3; 1; 2; 4; 6; 5] in
+  let m = Ptmap.add_seq (List.to_seq (List.map (fun v -> (v, true)) a)) (list_to_map o) in
+  assert (Ptmap.cardinal m = List.length r);
+  assert (Ptmap.for_all (fun k v -> List.exists (fun ok -> ok = k) r) m)
+
 let main () =
   test Ptmap.empty Ptmap.add Ptmap.mem;
   test_find_first;
@@ -70,6 +97,9 @@ let main () =
   test_find_last_opt;
   test_update_remove;
   test_update_add;
-  test_update_update
+  test_update_update;
+  test_to_seq;
+  test_to_seq_from;
+  test_of_seq
 
 let () = main ()


### PR DESCRIPTION
The methods are not ordered as specified by the doc (see #11), but at least they will make ptmap compilable with OCaml 4.07.