### PR TITLE
OCaml 4.11 support

### DIFF
--- a/ptmap.ml
+++ b/ptmap.ml
@@ -188,6 +188,11 @@ let rec filter pr = function
   | Leaf (k, v) as t -> if pr k v then t else Empty
   | Branch (p,m,t0,t1) -> branch (p, m, filter pr t0, filter pr t1)
 
+let rec filter_map f = function
+  | Empty -> Empty
+  | Leaf (k, v) -> (match f k v with Some v -> Leaf (k, v) | None -> Empty)
+  | Branch (p,m,t0,t1) -> branch (p, m, filter_map f t0, filter_map f t1)
+
 let partition p s =
   let rec part (t,f as acc) = function
     | Empty -> acc


### PR DESCRIPTION
OCaml 4.11 now includes a `Map.Make(...).filter_map` function and the latest release fails to build because its interface must be equivalent to the interface of `Map.S`. This PR fixes the issue